### PR TITLE
feat: Add support for server side rendering

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,8 +30,9 @@ const config = {
   output: {
     filename: "index.js",
     path: path.resolve(__dirname, "dist"),
-    library: 'useRedux',
-    libraryTarget: 'umd'
+    library: 'reactAnimeJs',
+    libraryTarget: 'umd',
+    globalObject: 'this'
   },
   plugins: [
     new CleanWebpackPlugin()


### PR DESCRIPTION
Hey :)

If I am using any `<Anime>` component the entire server side rendering explodes with the following error: 

```
@mollycule/react-anime/dist/index.js?:3
  }(window, (function(e, t, r) {
    ^
  ReferenceError: window is not defined
```

this pull request uses the global `this` instead to get around that issue as recommend here:

https://webpack.js.org/configuration/output/#outputglobalobject

I also renamed the library from `useRedux` to `reactAnimeJs` 😉 